### PR TITLE
Add Cluster Chooser and Comprehensive Installer Enhancements

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -446,8 +446,7 @@ EOL
 upgrade_install() {
     sudoCheck
     start_install
-    ensure_xandeum_pod_tmpfile
-    show_completion_and_restart "update"
+    # Note: show_completion_and_restart is called within start_install
 }
 
 start_install() {

--- a/install.sh
+++ b/install.sh
@@ -361,6 +361,11 @@ start_install() {
                 git checkout "$XANDMINER_BRANCH"
                 git pull origin "$XANDMINER_BRANCH"
             else
+                git fetch origin
+                # Get the default branch from remote
+                DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD --short | sed 's@^origin/@@')
+                echo "Checking out default branch: $DEFAULT_BRANCH"
+                git checkout "$DEFAULT_BRANCH"
                 git pull
             fi
         )
@@ -373,6 +378,11 @@ start_install() {
                 git checkout "$XANDMINERD_BRANCH"
                 git pull origin "$XANDMINERD_BRANCH"
             else
+                git fetch origin
+                # Get the default branch from remote
+                DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD --short | sed 's@^origin/@@')
+                echo "Checking out default branch: $DEFAULT_BRANCH"
+                git checkout "$DEFAULT_BRANCH"
                 git pull
             fi
 


### PR DESCRIPTION
# Feature: Cluster Chooser and Comprehensive Installer Enhancements

## Overview
This PR adds comprehensive improvements to the xandminer-installer script, including atlas cluster selection, dev mode enhancements, log management, and various UX improvements.

## Features Added

### 🎯 Atlas Cluster Selector
- Added `--atlas-cluster` CLI argument supporting `trynet`, `devnet`, and `mainnet-alpha`
- Interactive cluster selection menu with clear options
- Automatic hostname/IP mapping for each cluster
- **Mainnet-alpha support**: Uses `--mainnet-alpha` flag (includes gossip peers) instead of `--atlas-ip`
- Default cluster: `devnet` if not specified

### 🔧 Dev Mode Enhancements
- Restored full dev mode functionality with interactive branch selection
- `select_branch()` function: Reads and displays available branches from xandminer and xandminerd repos
- `select_pod_version()` function: Shows trynet pod versions with timestamps and commit hashes
- Interactive prompts for selecting branches and pod trynet versions
- Non-interactive dev mode uses default branches (master/master/stable)

### 📝 Pod Log Configuration
- Added `--log-path` CLI argument for custom log file paths
- Default log path: `/root/pod-logs/pod.log`
- Automatic directory creation
- **Logrotate integration**: Automatically configures logrotate when logs are enabled
  - Daily rotation
  - 7 days retention
  - Compression enabled
  - Automatic pod service reload after rotation

### 🛠️ Bug Fixes
- **Fixed `show_help()` function**: Moved function definition to top of script (before it's called)
- **Fixed pod version selection**: Prevents trynet versions from being installed in non-dev mode
  - Removes trynet repository file in standard mode
  - Detects and removes existing trynet pod installations
  - Explicitly installs stable pod version (0.8.0-1)
  - Uses `--allow-downgrades` when needed

### 🎨 UX Improvements
- Added separator lines (`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`) to all configuration prompts
- Added "(default)" indicators next to default options
- Added "press Enter for default" messaging to all prompts
- Changed pRPC default from Public to Private
- Improved configuration summary output

### ⚙️ Service Management
- Services now restart at the end of installation (not immediately)
- 30-second delay before restart in non-interactive mode
- All services (pod, xandminerd, xandminer) restart together
- Proper service ordering and dependency handling

## CLI Arguments

```
-n, --non-interactive    Run in non-interactive mode (requires --install or --update)
--install                Perform fresh installation
--update                 Update existing installation
-d, --dev                Enable dev mode (interactive branch selection)
--default-keypair        Use default keypair path
--keypair-path PATH      Specify custom keypair path
--prpc-mode MODE         Set pRPC mode: 'public' or 'private'
--atlas-cluster CLUSTER  Set Atlas cluster: 'trynet', 'devnet', or 'mainnet-alpha'
--log-path PATH          Set pod log file path (default: /root/pod-logs/pod.log)
-h, --help               Show help message
```

## Examples

```bash
# Interactive installation with cluster selection
sudo bash install.sh

# Non-interactive with mainnet-alpha
sudo bash install.sh --non-interactive --install --default-keypair --prpc-mode private --atlas-cluster mainnet-alpha

# Dev mode with branch selection
sudo bash install.sh -d

# Custom log path
sudo bash install.sh --non-interactive --install --log-path /var/log/pod.log
```

## Testing
- ✅ Help command works correctly
- ✅ All interactive prompts display properly with separators
- ✅ Default options work when pressing Enter
- ✅ Dev mode branch selection functional
- ✅ Trynet pod version selection functional
- ✅ Logrotate configuration created automatically
- ✅ Stable pod version installed in non-dev mode
- ✅ Mainnet-alpha uses correct flag
- ✅ Services restart correctly at end

## Breaking Changes
None - all changes are backward compatible.

## Related Issues
Fixes issues with:
- Help command not working
- Trynet pod versions being installed in standard mode
- Missing dev mode functionality
- Services restarting too early